### PR TITLE
PersistenceUnitName Overwrite

### DIFF
--- a/src/app/n2n/core/container/PdoPool.php
+++ b/src/app/n2n/core/container/PdoPool.php
@@ -122,7 +122,7 @@ class PdoPool implements ThreadScoped {
 	 * @return \n2n\persistence\orm\EntityManagerFactory
 	 */
 	public function getEntityManagerFactory($persistenceUnitName = null) {
-		if ($persistenceUnitName !== null) {
+		if ($persistenceUnitName === null) {
 			$persistenceUnitName = self::DEFAULT_DS_NAME;
 		}
 		


### PR DESCRIPTION
Use default persistenceUnitName only when persistenceUnitName parameter is null. Not the other way around.